### PR TITLE
Alpine

### DIFF
--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,7 +1,5 @@
-FROM elixir:1.5-alpine
+FROM elixir:1.6-alpine
 
 ENV PHOENIX_VERSION 1.3.0
 
 RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phx_new-1.3.0.ez
-
-RUN elixir -v

--- a/alpine/Dockerfile
+++ b/alpine/Dockerfile
@@ -1,0 +1,7 @@
+FROM elixir:1.5-alpine
+
+ENV PHOENIX_VERSION 1.3.0
+
+RUN mix archive.install --force https://github.com/phoenixframework/archives/raw/master/phx_new-1.3.0.ez
+
+RUN elixir -v


### PR DESCRIPTION
I added a build in Docker Hub build setting for this repo. Git tags will also build/tag the alpine version similar to what we do for the full image version.

e.g. git tag of `1.3` yields image and tag `podium/phoenix:1.3-alpine`.